### PR TITLE
Opensees-express singularity 

### DIFF
--- a/img-classify/app_definition.json
+++ b/img-classify/app_definition.json
@@ -1,5 +1,5 @@
 {
-    "id": "<username>-img-classify",
+    "id": "kprice-img-classify",
     "version": "0.1",
     "description": "An image classifier run using Singularity in batch mode.",
     "jobType": "BATCH",

--- a/img-classify/job_definition.json
+++ b/img-classify/job_definition.json
@@ -2,7 +2,7 @@
     "name": "img-classify-job",
     "appId": "<username>-img-classify",
     "appVersion": "0.1",
-    "execSystemId": "<SYSTEM_NAME_HERE>",
+    "execSystemId": "<system name>",
     "parameterSet": {
         "appArgs": [
             {
@@ -10,14 +10,6 @@
             },
             {
                 "arg": "'https://s3.amazonaws.com/cdn-origin-etr.akc.org/wp-content/uploads/2017/11/12231410/Labrador-Retriever-On-White-01.jpg'"
-            }
-        ],
-        "schedulerOptions": [
-            {
-                "arg": "--tapis-profile tacc"
-            },
-            {
-                "arg": "--account <ACCOUNT_ALLOCATION>"
             }
         ]
     }

--- a/jupyter-notebook/app_definition.json
+++ b/jupyter-notebook/app_definition.json
@@ -1,5 +1,5 @@
 {
-    "id": "jupyter-notebook-hpc",
+    "id": "jupyter-notebook-hpc-kprice3",
     "version": "1",
     "description": "A reference application for running an HPC version of Jupyter Notebook in Tapis v3. Runs interactively on a Stampede2 or Frontera compute node.",
     "jobType": "BATCH",

--- a/jupyter-notebook/app_definition.json
+++ b/jupyter-notebook/app_definition.json
@@ -1,5 +1,5 @@
 {
-    "id": "jupyter-notebook-hpc-kprice3",
+    "id": "jupyter-notebook-hpc-<username>",
     "version": "1",
     "description": "A reference application for running an HPC version of Jupyter Notebook in Tapis v3. Runs interactively on a Stampede2 or Frontera compute node.",
     "jobType": "BATCH",

--- a/jupyter-notebook/job_definition.json
+++ b/jupyter-notebook/job_definition.json
@@ -1,6 +1,24 @@
 {
     "name": "jupyter-notebook-hpc-job",
-    "appId": "jupyter-notebook-hpc",
+    "appId": "jupyter-notebook-hpc-<username>",
     "appVersion": "1",
-    "execSystemId": "<SYSTEM_NAME_HERE>"
+    "execSystemId": "<system id>",
+    "parameterSet": {
+        "schedulerOptions": [
+            { 
+                "name": "chargeProject",
+                "description": "which project to charge",
+                "include": true,
+                "arg": "-A TACC-ACI-CIC"
+    
+            },
+            {
+                "name": "profile",
+                "description": "which scheduler profile to use",
+                "include": true,
+                "arg": "--tapis-profile tacc"
+            }
+        ]
+
+    }
 }

--- a/opensees-express/README.md
+++ b/opensees-express/README.md
@@ -29,7 +29,14 @@ To run the app on a specified system instead of a publicly shared one, users can
 <br>
 
 If using a job definition template, be sure to replace the "<SYSTEM_NAME_HERE>" and "<XXX_FILE>" values with a specific system and file paths as appropriate!
+
+<br>
+
+# Switching between Docker and Singularity runtimes
+The jobs are set to use the singularity runtime by default. If you've registered the Docker runtime app using `app_definition_docker.json`, you'll need to make sure to switch the `"appId": "opensees-express-singularity-<username>",` line in the job definition file to `"appId": "opensees-express-docker-<username>",`
 <br><br> 
+
+
 
 
 ## Handling input files

--- a/opensees-express/app_definition_docker.json
+++ b/opensees-express/app_definition_docker.json
@@ -1,7 +1,7 @@
 {
-    "id": "opensees-express",
+    "id": "opensees-express-<username>",
     "version": "1",
-    "appType": "FORK",
+    "jobType": "BATCH",
     "runtime": "DOCKER",
     "description": "A reference application for running OpenSees Express in Tapis v3.",
     "containerImage": "stevemock/docker-opensees:latest",
@@ -19,7 +19,7 @@
             {
                 "name": "TCL_input",
                 "inputMode": "REQUIRED",
-                "sourceUrl": "tapis://<SYSTEM_NAME_HERE>/<DEFAULT_TCL_FILE>.tcl",
+                "sourceUrl": "tapis://<SYSTEM_NAME_HERE>/<NEW_TCL_FILE>.tcl",
                 "targetPath": "input.tcl"
             }
         ]

--- a/opensees-express/app_definition_singularity.json
+++ b/opensees-express/app_definition_singularity.json
@@ -1,0 +1,28 @@
+{
+    "id": "opensees-express-singularity-<username>",
+    "version": "1",
+    "jobType": "BATCH",
+    "runtime": "SINGULARITY",
+    "runtimeOptions": ["SINGULARITY_RUN"],
+    "description": "A reference application for running OpenSees Express in Tapis v3.",
+    "containerImage": "docker://stevemock/docker-opensees:latest",
+    "jobAttributes": {
+        "execSystemExecDir": "${JobWorkingDir}/jobs/${JobUUID}",
+        "execSystemInputDir": "${JobWorkingDir}/jobs/${JobUUID}/data",
+        "execSystemOutputDir": "${JobWorkingDir}/jobs/${JobUUID}/output",
+        "parameterSet": {
+            "appArgs": [
+                {"name": "mainProgram", "arg": "OpenSees"},
+                {"name": "input1", "arg": "/TapisInput/input.tcl"}
+            ] 
+        },
+        "fileInputs": [
+            {
+                "name": "TCL_input",
+                "inputMode": "REQUIRED",
+                "sourceUrl": "tapis://<SYSTEM_NAME_HERE>/<NEW_TCL_FILE>.tcl",
+                "targetPath": "input.tcl"
+            }
+        ]
+    }
+}

--- a/opensees-express/job_definition_default.json
+++ b/opensees-express/job_definition_default.json
@@ -1,6 +1,6 @@
 {
     "name": "opensees-express-job",
-    "appId": "opensees-express",
+    "appId": "opensees-express-singularity-<username>",
     "appVersion": "1",
-    "execSystemId": "<SYSTEM_NAME_HERE>"
+    "execSystemId": "<system id>"
 }

--- a/opensees-express/job_definition_file_override.json
+++ b/opensees-express/job_definition_file_override.json
@@ -1,6 +1,6 @@
 {
-    "name": "opensees-express-default-input-override",
-    "appId": "opensees-express",
+    "name": "opensees-express-default-input-override-<username>",
+    "appId": "opensees-express-singularity-<username>",
     "appVersion": "1",
     "fileInputs": [
         {

--- a/opensees-express/job_definition_multiple_inputs.json
+++ b/opensees-express/job_definition_multiple_inputs.json
@@ -1,6 +1,6 @@
 {
     "name": "opensees-express-multiple-file-inputs",
-    "appId": "opensees-express",
+    "appId": "opensees-express-singularity-<username>",
     "appVersion": "1",
     "fileInputs": [
         {


### PR DESCRIPTION
adds openseees-express-singularity and changes the default app to openseees-express-docker
adds a note in the readme about switching between the two
adds <username> to app names in an attempt to remove naming conflicts / be consistent with other apps